### PR TITLE
Don't set missing keys to null.

### DIFF
--- a/lib/asn1/base/node.js
+++ b/lib/asn1/base/node.js
@@ -341,7 +341,7 @@ Node.prototype._decode = function decode(input) {
     result = input.leaveObject(prevObj);
 
   // Set key
-  if (state.key !== null)
+  if (state.key !== null && (result !== null || present === true))
     input.leaveKey(prevKey, state.key, result);
 
   return result;

--- a/test/ping-pong-test.js
+++ b/test/ping-pong-test.js
@@ -121,6 +121,12 @@ describe('asn1.js ping/pong', function() {
       );
     }, { hello: 'devs' }, { hello: 'devs', how: 'are you' });
 
+    test('optionals #3', function() {
+      this.seq().obj(
+        this.key('content').optional().int()
+      );
+    }, {}, {});
+
     test('seqof', function() {
       var S = asn1.define('S', function() {
         this.seq().obj(


### PR DESCRIPTION
If key is missing from input it should not be set
to null in resulting object because such object
can't be but back into encoder.

fixes #9
