### PR TITLE
Properly encode IMPLICIT tag

### DIFF
--- a/lib/asn1/base/node.js
+++ b/lib/asn1/base/node.js
@@ -489,7 +489,7 @@ Node.prototype._encode = function encode(data, reporter) {
           return this._getUse(state.args[0])._encode(item, reporter);
         }, this));
       } else if (state.use !== null) {
-        result = this._getUse(state.use)._encode(data, reporter);
+        return this._getUse(state.use)._encode(data, reporter);
       } else {
         content = this._encodePrimitive(state.tag, data);
         primitive = true;
@@ -503,12 +503,13 @@ Node.prototype._encode = function encode(data, reporter) {
   var result;
   if (!state.any && state.choice === null) {
     var tag = state.implicit !== null ? state.implicit : state.tag;
+    var cls = state.implicit === null ? 'universal' : 'context';
 
     if (tag === null) {
       if (state.use === null)
         reporter.error('Tag could be ommited only for .use()');
     } else {
-      result = this._encodeComposite(tag, primitive, 'universal', content);
+      result = this._encodeComposite(tag, primitive, cls, content);
     }
   }
 

--- a/test/use-test.js
+++ b/test/use-test.js
@@ -1,0 +1,50 @@
+var assert = require('assert');
+var asn1 = require('..');
+
+var Buffer = require('buffer').Buffer;
+
+describe('asn1.js models', function() {
+  describe('plain use', function() {
+    it('should encode submodel', function() {
+      var SubModel = asn1.define('SubModel', function() {
+        this.seq().obj(
+          this.key('b').octstr()
+        );
+      });
+      var Model = asn1.define('Model', function() {
+        this.seq().obj(
+          this.key('a').int(),
+          this.key('sub').use(SubModel)
+        );
+      });
+
+      var data = {a: 1, sub: {b: new Buffer("XXX")}};
+      var wire = Model.encode(data, 'der');
+      assert.equal(wire.toString('hex'), '300a02010130050403585858');
+      var back = Model.decode(wire, 'der');
+      assert.deepEqual(back, data);
+    });
+
+    it('should honour implicit tag from parent', function() {
+      var SubModel = asn1.define('SubModel', function() {
+        this.seq().obj(
+          this.key('x').octstr()
+        )
+      });
+      var Model = asn1.define('Model', function() {
+        this.seq().obj(
+          this.key('a').int(),
+          this.key('sub').use(SubModel).implicit(0)
+        );
+      });
+
+      var data = {a: 1, sub: {x: new Buffer("123")}};
+      var wire = Model.encode(data, 'der');
+      assert.equal(wire.toString('hex'), '300a020101a0050403313233');
+      var back = Model.decode(wire, 'der');
+      assert.deepEqual(back, data);
+
+    });
+  });
+});
+


### PR DESCRIPTION
Implicit tags are once again broken for submodels.

This patch fixes both incorrect encoding and broken code.
