### PR TITLE
Use function

### DIFF
--- a/lib/asn1/base/node.js
+++ b/lib/asn1/base/node.js
@@ -369,18 +369,19 @@ Node.prototype._decodeGeneric = function decodeGeneric(tag, input) {
   else if (tag === 'int' || tag === 'enum')
     return this._decodeInt(input, state.args && state.args[0]);
   else if (state.use !== null)
-    return this._getUse(state.use)._decode(input);
+    return this._getUse(state.use, input._reporterState.obj)._decode(input);
   else
     return input.error('unknown tag: ' + tag);
 
   return null;
 };
 
-Node.prototype._getUse = function _getUse(entity) {
+Node.prototype._getUse = function _getUse(entity, obj) {
+
   var state = this._baseState;
   if (!state.useDecoder) {
     // Create altered use decoder if implicit is set
-    state.useDecoder = this._use(entity);
+    state.useDecoder = this._use(entity, obj);
     assert(state.useDecoder._baseState.parent === null);
     state.useDecoder = state.useDecoder._baseState.children[0];
     if (state.implicit !== null) {
@@ -427,7 +428,7 @@ Node.prototype._createEncoderBuffer = function createEncoderBuffer(data) {
   return new EncoderBuffer(data, this.reporter);
 };
 
-Node.prototype._encode = function encode(data, reporter) {
+Node.prototype._encode = function encode(data, reporter, parent) {
   var state = this._baseState;
 
   // Decode root node
@@ -468,7 +469,7 @@ Node.prototype._encode = function encode(data, reporter) {
       if (typeof data !== 'object')
         return reporter.error('Child expected, but input is not object');
 
-      var res = child._encode(data[child._baseState.key], reporter);
+      var res = child._encode(data[child._baseState.key], reporter, data);
       reporter.leaveKey(prevKey);
 
       return res;
@@ -487,10 +488,10 @@ Node.prototype._encode = function encode(data, reporter) {
         return reporter.error('seqof/setof, but data is not Array');
 
       content = this._createEncoderBuffer(data.map(function(item) {
-        return this._getUse(state.args[0])._encode(item, reporter);
+        return this._getUse(state.args[0], data)._encode(item, reporter);
       }, this));
     } else if (state.use !== null) {
-      result = this._getUse(state.use)._encode(data, reporter);
+      result = this._getUse(state.use, parent)._encode(data, reporter);
     } else {
       content = this._encodePrimitive(state.tag, data);
       primitive = true;

--- a/lib/asn1/decoders/der.js
+++ b/lib/asn1/decoders/der.js
@@ -224,7 +224,9 @@ DERNode.prototype._decodeInt = function decodeInt(buffer, values) {
   return res;
 };
 
-DERNode.prototype._use = function use(entity) {
+DERNode.prototype._use = function use(entity, obj) {
+  if (typeof entity === 'function')
+    entity = entity(obj);
   return entity._getDecoder('der').tree;
 };
 

--- a/lib/asn1/encoders/der.js
+++ b/lib/asn1/encoders/der.js
@@ -200,7 +200,9 @@ DERNode.prototype._encodeBool = function encodeBool(value) {
   return this._createEncoderBuffer(value ? 0xff : 0);
 };
 
-DERNode.prototype._use = function use(entity) {
+DERNode.prototype._use = function use(entity, obj) {
+  if (typeof entity === 'function')
+    entity = entity(obj);
   return entity._getEncoder('der').tree;
 };
 

--- a/test/use-test.js
+++ b/test/use-test.js
@@ -67,6 +67,30 @@ describe('asn1.js models', function() {
 
     });
 
+    it('should get model with function call', function() {
+      var SubModel = asn1.define('SubModel', function() {
+        this.seq().obj(
+          this.key('x').octstr()
+        )
+      });
+      var Model = asn1.define('Model', function() {
+        this.seq().obj(
+          this.key('a').int(),
+          this.key('sub').use(function(obj) {
+              assert.equal(obj.a, 1);
+              return SubModel;
+          })
+        );
+      });
+
+      var data = {a: 1, sub: {x: new Buffer("123")}};
+      var wire = Model.encode(data, 'der');
+      assert.equal(wire.toString('hex'), '300a02010130050403313233');
+      var back = Model.decode(wire, 'der');
+      assert.deepEqual(back, data);
+
+    });
+
   });
 });
 


### PR DESCRIPTION
Add a way to change submodels on the fly, by passing routing function to use().

Usage example:

``` javascript
var ContenModels = {
    signedData: SignedData,
    envelopedData: EnvelopedData
};

var ContentInfo = asn1.define('ContentInfo', function() {
    this.seq().obj(
        this.key('contentType').objid(PKCS7_CONTENT_TYPES),
        this.key('content').optional().explicit(0).use(function () {
            return ContenModels[this.contentType];
       })
    );
});
```
