### PR TITLE
Properly encode IMPLICIT tag

### DIFF
--- a/lib/asn1/base/node.js
+++ b/lib/asn1/base/node.js
@@ -489,7 +489,7 @@ Node.prototype._encode = function encode(data, reporter) {
           return this._getUse(state.args[0])._encode(item, reporter);
         }, this));
       } else if (state.use !== null) {
-        return this._getUse(state.use)._encode(data, reporter);
+        result = this._getUse(state.use)._encode(data, reporter);
       } else {
         content = this._encodePrimitive(state.tag, data);
         primitive = true;
@@ -509,7 +509,8 @@ Node.prototype._encode = function encode(data, reporter) {
       if (state.use === null)
         reporter.error('Tag could be ommited only for .use()');
     } else {
-      result = this._encodeComposite(tag, primitive, cls, content);
+      if (state.use === null)
+        result = this._encodeComposite(tag, primitive, cls, content);
     }
   }
 

--- a/test/use-test.js
+++ b/test/use-test.js
@@ -45,6 +45,28 @@ describe('asn1.js models', function() {
       assert.deepEqual(back, data);
 
     });
+
+    it('should honour explicit tag from parent', function() {
+      var SubModel = asn1.define('SubModel', function() {
+        this.seq().obj(
+          this.key('x').octstr()
+        )
+      });
+      var Model = asn1.define('Model', function() {
+        this.seq().obj(
+          this.key('a').int(),
+          this.key('sub').use(SubModel).explicit(0)
+        );
+      });
+
+      var data = {a: 1, sub: {x: new Buffer("123")}};
+      var wire = Model.encode(data, 'der');
+      assert.equal(wire.toString('hex'), '300c020101a00730050403313233');
+      var back = Model.decode(wire, 'der');
+      assert.deepEqual(back, data);
+
+    });
+
   });
 });
 


### PR DESCRIPTION
Add tests for IMPLICIT and EXPLICIT tags with submodel and fix broken code.
