### PR TITLE
fix: TBSCertificate extension parsing.

### DIFF
--- a/rfc/3280/index.js
+++ b/rfc/3280/index.js
@@ -108,9 +108,9 @@ exports.Extensions = Extensions;
 
 var Extension = asn1.define('Extension', function() {
   this.seq().obj(
-    this.key('extnID').objid(),
+    this.key('extnID').optional().objid(),
     this.key('critical').bool().def(false),
-    this.key('extnValue').octstr()
+    this.key('extnValue').optional().octstr()
   );
 });
 exports.Extension = Extension;


### PR DESCRIPTION
@indutny, I'm getting this error when parsing a DER cert:

``` bash
Error: Failed to match tag: "objid" at: ["tbsCertificate"]["issuerUniqueID"]["subjectUniqueID"]["extensions"]["extnID"]
```

This PR seems to fix it. The DER in question is at: https://github.com/bitpay/bitcore/blob/master/test/data/x509.der
