### PR TITLE
Integer sign 80

### DIFF
--- a/lib/asn1/encoders/der.js
+++ b/lib/asn1/encoders/der.js
@@ -169,8 +169,13 @@ DERNode.prototype._encodeInt = function encodeInt(num, values) {
   }
 
   // Bignum, assume big endian
-  if (bignum !== null && num instanceof bignum)
-    num = new Buffer(num.toArray());
+  if (bignum !== null && num instanceof bignum) {
+    var numArray = num.toArray();
+    if(num.sign === false && numArray[0] & 0x80) {
+      numArray.unshift(0);
+    }
+    num = new Buffer(numArray);
+  }
 
   if (Buffer.isBuffer(num)) {
     var size = num.length;
@@ -184,20 +189,26 @@ DERNode.prototype._encodeInt = function encodeInt(num, values) {
     return this._createEncoderBuffer(out);
   }
 
-  if (num < 0x100)
+  if (num < 0x80)
     return this._createEncoderBuffer(num);
+
+  if (num < 0x100)
+    return this._createEncoderBuffer([0, num]);
 
   var size = 1;
   for (var i = num; i >= 0x100; i >>= 8)
     size++;
 
-  var out = new Buffer(size);
+  var out = new Array(size);
   for (var i = out.length - 1; i >= 0; i--) {
     out[i] = num & 0xff;
     num >>= 8;
   }
+  if(out[0] & 0x80) {
+    out.unshift(0);
+  }
 
-  return this._createEncoderBuffer(out);
+  return this._createEncoderBuffer(new Buffer(out));
 };
 
 DERNode.prototype._encodeBool = function encodeBool(value) {

--- a/test/der-encode-test.js
+++ b/test/der-encode-test.js
@@ -1,5 +1,6 @@
 var assert = require('assert');
 var asn1 = require('..');
+var BN = require('bn.js');
 
 var Buffer = require('buffer').Buffer;
 
@@ -48,5 +49,17 @@ describe('asn1.js DER encoder', function() {
     });
     this.explicit(0).seqof(Int);
   }, [ 1 ], 'A0053003020101' );
+
+  test('should encode BN(128) properly', function() {
+    this.int();
+  }, new BN(128), '02020080');
+
+  test('should encode int 128 properly', function() {
+    this.int();
+  }, 128, '02020080');
+
+  test('should encode 0x8011 properly', function() {
+    this.int();
+  }, 0x8011, '0203008011');
 
 });


### PR DESCRIPTION
Nonegative integers can have highest bit (0x80) which makes them interpreted as negative numbers.

When encoding such integers, prepend 00 byte before first byte to force positive number detection.
