### PR TITLE
Der default values

### DIFF
--- a/lib/asn1/base/node.js
+++ b/lib/asn1/base/node.js
@@ -430,6 +430,21 @@ Node.prototype._createEncoderBuffer = function createEncoderBuffer(data) {
 
 Node.prototype._encode = function encode(data, reporter, parent) {
   var state = this._baseState;
+  if (state['default'] !== null && state['default'] === data)
+    return;
+
+  var result = this._encodeValue(data, reporter, parent);
+  if (result === undefined)
+    return;
+
+  if (this._skipDefault(result, reporter, parent))
+    return;
+
+  return result;
+};
+
+Node.prototype._encodeValue = function encode(data, reporter, parent) {
+  var state = this._baseState;
 
   // Decode root node
   if (state.parent === null)

--- a/lib/asn1/encoders/der.js
+++ b/lib/asn1/encoders/der.js
@@ -221,6 +221,26 @@ DERNode.prototype._use = function use(entity, obj) {
   return entity._getEncoder('der').tree;
 };
 
+DERNode.prototype._skipDefault = function skipDefault(dataBuffer, reporter, parent) {
+  var state = this._baseState;
+  var i;
+  if (state['default'] === null)
+    return false;
+
+  var data = dataBuffer.join();
+  if (state.defaultBuffer === undefined)
+    state.defaultBuffer = this._encodeValue(state['default'], reporter, parent).join();
+
+  if (data.length !== state.defaultBuffer.length)
+    return false;
+
+  for (i=0; i < data.length; i++)
+    if (data[i] !== state.defaultBuffer[i])
+      return false;
+
+  return true;
+};
+
 // Utility methods
 
 function encodeTag(tag, primitive, cls, reporter) {

--- a/test/der-encode-test.js
+++ b/test/der-encode-test.js
@@ -62,4 +62,10 @@ describe('asn1.js DER encoder', function() {
     this.int();
   }, 0x8011, '0203008011');
 
+  test('should omit default value in DER', function() {
+    this.seq().obj(
+      this.key('required').def(false).bool(),
+      this.key('value').int()
+    );
+  }, {required: false, value: 1}, '3003020101');
 });

--- a/test/ping-pong-test.js
+++ b/test/ping-pong-test.js
@@ -71,11 +71,13 @@ describe('asn1.js ping/pong', function() {
                   'c6dc153ea90a42c1ca41929ac1b9', 'hex'));
 
     test('default explicit', function() {
-      this.def('v1').explicit(0).int({
-        0: 'v1',
-        1: 'v2'
-      });
-    }, undefined, 'v1');
+      this.seq().obj(
+        this.key('version').def('v1').explicit(0).int({
+          0: 'v1',
+          1: 'v2'
+        })
+      );
+    }, {}, {'version': 'v1'});
 
     test('implicit', function() {
       this.implicit(0).int({


### PR DESCRIPTION
DER encoder should not include values that are equual to defaults.

Ref http://luca.ntop.org/Teaching/Appunti/asn1.html:

```
DER encoding. Constructed. Contents octets are the same as the BER
encoding, except that if the value of a component with the DEFAULT
qualifier is the default value, the encoding of that component is not
included in the contents octets.
```
