### PR TITLE
Fix strict mode error in Node.prototype.keys

### DIFF
--- a/lib/asn1/base/node.js
+++ b/lib/asn1/base/node.js
@@ -222,11 +222,11 @@ Node.prototype.obj = function obj() {
   return this;
 };
 
-Node.prototype.key = function key(key) {
+Node.prototype.key = function key(newKey) {
   var state = this._baseState;
 
   assert(state.key === null);
-  state.key = key;
+  state.key = newKey;
 
   return this;
 };


### PR DESCRIPTION
Having an argument with the same name as a named function expression is a syntax error in strict mode, which can cause errors when combined with other files using strict mode. See http://stackoverflow.com/q/28170788 for an example of this bug.