### PR TITLE
api: fallback to anonymous function

### DIFF
--- a/lib/asn1/api.js
+++ b/lib/asn1/api.js
@@ -1,6 +1,5 @@
 var asn1 = require('../asn1');
 var inherits = require('inherits');
-var vm = require('vm');
 
 var api = exports;
 
@@ -17,9 +16,18 @@ function Entity(name, body) {
 };
 
 Entity.prototype._createNamed = function createNamed(base) {
-  var named = vm.runInThisContext('(function ' + this.name + '(entity) {\n' +
-    '  this._initNamed(entity);\n' +
-    '})');
+  var named;
+  try {
+    named = require('vm').runInThisContext(
+      '(function ' + this.name + '(entity) {\n' +
+      '  this._initNamed(entity);\n' +
+      '})'
+    );
+  } catch (e) {
+    named = function (entity) {
+      this._initNamed(entity);
+    };
+  }
   inherits(named, base);
   named.prototype._initNamed = function initnamed(entity) {
     base.call(this, entity);


### PR DESCRIPTION
`vm-browserify` uses `eval()` which is disabled in Chrome Apps (completely)
and Extensions (by default CSP). If can't execute `vm.runInThisContext`
to create named function, fallback to unnamed function expression.