### PR TITLE
Return original OID if no mapping was provided

### DIFF
--- a/lib/asn1/decoders/der.js
+++ b/lib/asn1/decoders/der.js
@@ -160,7 +160,7 @@ DERNode.prototype._decodeObjid = function decodeObjid(buffer, values, relative) 
     result = [first, second].concat(identifiers.slice(1));
 
   var key = result.join(' ');
-  if (values && typeof values[key] !== 'undefined')
+  if (values && values[key] !== undefined)
     result = values[key];
 
   return result;

--- a/lib/asn1/decoders/der.js
+++ b/lib/asn1/decoders/der.js
@@ -161,6 +161,8 @@ DERNode.prototype._decodeObjid = function decodeObjid(buffer, values, relative) 
 
   if (values)
     result = values[result.join(' ')];
+  else
+    result = result.join('.');
 
   return result;
 };

--- a/lib/asn1/decoders/der.js
+++ b/lib/asn1/decoders/der.js
@@ -159,13 +159,9 @@ DERNode.prototype._decodeObjid = function decodeObjid(buffer, values, relative) 
   else
     result = [first, second].concat(identifiers.slice(1));
 
-  if (values) {
-    var key = result.join(' ');
-    if (key in values)
-      result = values[result.join(' ')];
-    else
-      return this.error('Unknown OID ' + key);
-  }
+  var key = result.join(' ');
+  if (values && typeof values[key] !== 'undefined')
+    result = values[key];
 
   return result;
 };

--- a/lib/asn1/decoders/der.js
+++ b/lib/asn1/decoders/der.js
@@ -159,10 +159,13 @@ DERNode.prototype._decodeObjid = function decodeObjid(buffer, values, relative) 
   else
     result = [first, second].concat(identifiers.slice(1));
 
-  if (values)
-    result = values[result.join(' ')];
-  else
-    result = result.join('.');
+  if (values) {
+    var key = result.join(' ');
+    if (key in values)
+      result = values[result.join(' ')];
+    else
+      return this.error('Unknown OID ' + key);
+  }
 
   return result;
 };

--- a/test/der-decode-test.js
+++ b/test/der-decode-test.js
@@ -69,4 +69,12 @@ describe('asn1.js DER decoder', function() {
     var out = A.decode(new Buffer('020101', 'hex'), 'der');
     assert.equal(out.toString(10), '1');
   });
+
+  it('should decode an unknown oid', function() {
+    var A = asn1.define('A', function() {
+        this.objid({'1 2 3': 'known'});
+    });
+    var out = A.decode(new Buffer('06022a04', 'hex'), 'der');
+    assert.deepEqual(out, [1,2,4] );
+  });
 });


### PR DESCRIPTION
This is my current solution to issue #20. I am encountering some obscure OIDs so rather than throw an error I would prefer to just return the OID string.