### PR TITLE
Removed all cyclic dependencies.

### DIFF
--- a/lib/asn1/api.js
+++ b/lib/asn1/api.js
@@ -1,4 +1,5 @@
-var asn1 = require('../asn1');
+var decoders = require('./decoders');
+var encoders = require('./encoders');
 var inherits = require('inherits');
 
 var api = exports;
@@ -39,7 +40,7 @@ Entity.prototype._createNamed = function createNamed(base) {
 Entity.prototype._getDecoder = function _getDecoder(enc) {
   // Lazily create decoder
   if (!this.decoders.hasOwnProperty(enc))
-    this.decoders[enc] = this._createNamed(asn1.decoders[enc]);
+    this.decoders[enc] = this._createNamed(decoders[enc]);
   return this.decoders[enc];
 };
 
@@ -50,7 +51,7 @@ Entity.prototype.decode = function decode(data, enc, options) {
 Entity.prototype._getEncoder = function _getEncoder(enc) {
   // Lazily create encoder
   if (!this.encoders.hasOwnProperty(enc))
-    this.encoders[enc] = this._createNamed(asn1.encoders[enc]);
+    this.encoders[enc] = this._createNamed(encoders[enc]);
   return this.encoders[enc];
 };
 

--- a/lib/asn1/base/buffer.js
+++ b/lib/asn1/base/buffer.js
@@ -1,5 +1,5 @@
 var inherits = require('inherits');
-var Reporter = require('../base').Reporter;
+var Reporter = require('./reporter').Reporter;
 var Buffer = require('buffer').Buffer;
 
 function DecoderBuffer(base, options) {

--- a/lib/asn1/base/node.js
+++ b/lib/asn1/base/node.js
@@ -1,5 +1,5 @@
-var Reporter = require('../base').Reporter;
-var EncoderBuffer = require('../base').EncoderBuffer;
+var Reporter = require('./reporter').Reporter;
+var EncoderBuffer = require('./buffer').EncoderBuffer;
 var assert = require('minimalistic-assert');
 
 // Supported tags

--- a/lib/asn1/constants/der.js
+++ b/lib/asn1/constants/der.js
@@ -1,4 +1,4 @@
-var constants = require('../constants');
+var utils = require('./utils');
 
 exports.tagClass = {
   0: 'universal',
@@ -6,7 +6,7 @@ exports.tagClass = {
   2: 'context',
   3: 'private'
 };
-exports.tagClassByName = constants._reverse(exports.tagClass);
+exports.tagClassByName = utils._reverse(exports.tagClass);
 
 exports.tag = {
   0x00: 'end',
@@ -39,4 +39,4 @@ exports.tag = {
   0x1d: 'charstr',
   0x1e: 'bmpstr'
 };
-exports.tagByName = constants._reverse(exports.tag);
+exports.tagByName = utils._reverse(exports.tag);

--- a/lib/asn1/constants/index.js
+++ b/lib/asn1/constants/index.js
@@ -1,19 +1,5 @@
 var constants = exports;
+var utils = require('./utils');
 
-// Helper
-constants._reverse = function reverse(map) {
-  var res = {};
-
-  Object.keys(map).forEach(function(key) {
-    // Convert key to integer if it is stringified
-    if ((key | 0) == key)
-      key = key | 0;
-
-    var value = map[key];
-    res[value] = key;
-  });
-
-  return res;
-};
-
+constants._reverse = utils._reverse;
 constants.der = require('./der');

--- a/lib/asn1/constants/utils.js
+++ b/lib/asn1/constants/utils.js
@@ -1,0 +1,14 @@
+exports._reverse = function reverse(map) {
+    var res = {};
+
+    Object.keys(map).forEach(function(key) {
+        // Convert key to integer if it is stringified
+        if ((key | 0) == key)
+            key = key | 0;
+
+        var value = map[key];
+        res[value] = key;
+    });
+
+    return res;
+};

--- a/lib/asn1/decoders/der.js
+++ b/lib/asn1/decoders/der.js
@@ -1,11 +1,8 @@
 var inherits = require('inherits');
 
-var asn1 = require('../../asn1');
-var base = asn1.base;
-var bignum = asn1.bignum;
-
-// Import DER constants
-var der = asn1.constants.der;
+var base = require('../base');
+var bignum = require('bn.js');
+var der = require('../constants/der');
 
 function DERDecoder(entity) {
   this.enc = 'der';

--- a/lib/asn1/decoders/pem.js
+++ b/lib/asn1/decoders/pem.js
@@ -1,7 +1,5 @@
 var inherits = require('inherits');
 var Buffer = require('buffer').Buffer;
-
-var asn1 = require('../../asn1');
 var DERDecoder = require('./der');
 
 function PEMDecoder(entity) {

--- a/lib/asn1/encoders/der.js
+++ b/lib/asn1/encoders/der.js
@@ -1,12 +1,10 @@
 var inherits = require('inherits');
 var Buffer = require('buffer').Buffer;
-
-var asn1 = require('../../asn1');
-var base = asn1.base;
-var bignum = asn1.bignum;
+var base = require('../base');
+var constants = require('../constants');
 
 // Import DER constants
-var der = asn1.constants.der;
+var der = constants.der;
 
 function DEREncoder(entity) {
   this.enc = 'der';

--- a/lib/asn1/encoders/pem.js
+++ b/lib/asn1/encoders/pem.js
@@ -1,7 +1,6 @@
 var inherits = require('inherits');
 var Buffer = require('buffer').Buffer;
 
-var asn1 = require('../../asn1');
 var DEREncoder = require('./der');
 
 function PEMEncoder(entity) {


### PR DESCRIPTION
Same story as in indutny/elliptic:
In my attempts to include this code in a React Native project I discovered a number of cyclic dependencies that prevented their default packager from completing. With the liberal rewriting of a few requires all the cycles have been eliminated (according to pahen/madge).

These changes are all superficial. All tests continue to pass.
