### PR TITLE
Add support for encapsulated models within bit and octet strings

### DIFF
--- a/lib/asn1/base/node.js
+++ b/lib/asn1/base/node.js
@@ -368,7 +368,7 @@ Node.prototype._decode = function decode(input) {
 
     // Decode contained/encoded by schema, only in bit or octet strings
     if (state.contains && (state.tag === 'octstr' || state.tag === 'bitstr')) {
-      data = new DecoderBuffer(result);
+      var data = new DecoderBuffer(result);
       result = this._getUse(state.contains, input._reporterState.obj)._decode(data);
     }
   }
@@ -514,6 +514,9 @@ Node.prototype._encodeValue = function encode(data, reporter, parent) {
     result = this._createEncoderBuffer(data);
   } else if (state.choice) {
     result = this._encodeChoice(data, reporter);
+  } else if (state.contains) {
+    content = this._getUse(state.contains, parent)._encode(data, reporter);
+    primitive = true;
   } else if (state.children) {
     content = state.children.map(function(child) {
       if (child._baseState.tag === 'null_')
@@ -533,7 +536,6 @@ Node.prototype._encodeValue = function encode(data, reporter, parent) {
     }, this).filter(function(child) {
       return child;
     });
-
     content = this._createEncoderBuffer(content);
   } else {
     if (state.tag === 'seqof' || state.tag === 'setof') {

--- a/lib/asn1/base/node.js
+++ b/lib/asn1/base/node.js
@@ -1,5 +1,6 @@
 var Reporter = require('../base').Reporter;
 var EncoderBuffer = require('../base').EncoderBuffer;
+var DecoderBuffer = require('../base').DecoderBuffer;
 var assert = require('minimalistic-assert');
 
 // Supported tags
@@ -12,7 +13,7 @@ var tags = [
 // Public methods list
 var methods = [
   'key', 'obj', 'use', 'optional', 'explicit', 'implicit', 'def', 'choice',
-  'any'
+  'any', 'contains'
 ].concat(tags);
 
 // Overrided methods list
@@ -48,6 +49,7 @@ function Node(enc, parent) {
   state['default'] = null;
   state.explicit = null;
   state.implicit = null;
+  state.contains = null;
 
   // Should create new instance on each method
   if (!state.parent) {
@@ -252,6 +254,15 @@ Node.prototype.choice = function choice(obj) {
   return this;
 };
 
+Node.prototype.contains = function contains(item) {
+  var state = this._baseState;
+
+  assert(state.use === null);
+  state.contains = item;
+
+  return this;
+};
+
 //
 // Decoding
 //
@@ -353,6 +364,12 @@ Node.prototype._decode = function decode(input) {
       });
       if (fail)
         return err;
+    }
+
+    // Decode contained/encoded by schema, only in bit or octet strings
+    if (state.contains && (state.tag === 'octstr' || state.tag === 'bitstr')) {
+      data = new DecoderBuffer(result);
+      result = this._getUse(state.contains, input._reporterState.obj)._decode(data);
     }
   }
 

--- a/test/der-decode-test.js
+++ b/test/der-decode-test.js
@@ -93,15 +93,15 @@ describe('asn1.js DER decoder', function() {
 
   it('should decode encapsulated models', function() {
     var B = asn1.define('B', function() {
-      this.int();
-    });
-
-    var A = asn1.define('A', function() {
       this.seq().obj(
-        this.key('nested').octstr().contains(B));
+        this.key('nested').int()
+      );
+    });
+    var A = asn1.define('A', function() {
+      this.octstr().contains(B);
     });
 
-    var out = A.decode(new Buffer('30050403020105', 'hex'), 'der');
+    var out = A.decode(new Buffer('04053003020105', 'hex'), 'der');
     assert.equal(out.nested.toString(10), '5');
   });
 });

--- a/test/der-decode-test.js
+++ b/test/der-decode-test.js
@@ -90,4 +90,18 @@ describe('asn1.js DER decoder', function() {
       '1.2.398.3.10.1.1.1.2.2': 'yes'
     });
   }, '060a2a830e030a0101010202', 'yes');
+
+  it('should decode encapsulated models', function() {
+    var B = asn1.define('B', function() {
+      this.int();
+    });
+
+    var A = asn1.define('A', function() {
+      this.seq().obj(
+        this.key('nested').octstr().contains(B));
+    });
+
+    var out = A.decode(new Buffer('30050403020105', 'hex'), 'der');
+    assert.equal(out.nested.toString(10), '5');
+  });
 });

--- a/test/der-encode-test.js
+++ b/test/der-encode-test.js
@@ -100,4 +100,18 @@ describe('asn1.js DER encoder', function() {
   test('should properly encode bmpstr with cyrillic chars', function() {
     this.bmpstr();
   }, 'Привет', '1e0c041f04400438043204350442');
+
+  it('should encode encapsulated models', function() {
+    var B = asn1.define('B', function() {
+      this.seq().obj(
+        this.key('nested').int()
+      );
+    });
+    var A = asn1.define('A', function() {
+      this.octstr().contains(B);
+    });
+
+    var out = A.encode({ nested: 5 }, 'der')
+    assert.equal(out.toString('hex'), '04053003020105');
+  });
 });


### PR DESCRIPTION
This should make decoding of things like RFC 5280 certificate extensions a little easier.