### PR TITLE
Enable merging of constructed, indefinite length encoded sub-strings

### DIFF
--- a/lib/asn1/decoders/der.js
+++ b/lib/asn1/decoders/der.js
@@ -96,7 +96,7 @@ DERNode.prototype._decodeTag = function decodeTag(buffer, tag, any) {
 
 DERNode.prototype._skipUntilEnd = function skipUntilEnd(buffer, fail) {
   // Capture sub-components for later merging
-  var remainders = []
+  var remainders = [];
   while (true) {
     var tag = derDecodeTag(buffer, fail);
     if (buffer.isError(tag))

--- a/lib/asn1/decoders/der.js
+++ b/lib/asn1/decoders/der.js
@@ -84,9 +84,9 @@ DERNode.prototype._decodeTag = function decodeTag(buffer, tag, any) {
   buffer.restore(state);
   var out = buffer.skip(len, 'Failed to match body of: "' + tag + '"');
 
+  // Octet and bit strings can be composed of sub-strings, each with its own
+  // tag header. Flag for later decode.
   if (res.length > 1) {
-    // Octet and bit strings can be composed of sub-strings, each with its own
-    // tag header. Flag for later decode.
     out.parts = res
   }
   return out
@@ -103,23 +103,26 @@ DERNode.prototype._skipUntilEnd = function skipUntilEnd(buffer, fail) {
     if (buffer.isError(len))
       return len;
 
+    // End Of Content
+    if (tag.cls === 'universal' && tag.tag == 0)
+      break;
+
     var res;
-    if (tag.primitive || len !== null)
+    if (tag.primitive || len !== null) {
       res = buffer.skip(len);
-    else
+      // Only collect parts for bit/octet strings
+      if (/^(bit|oct)str$/.test(tag.tagStr)) {
+        parts.push({
+          start: res.offset,
+          end: res.length
+        })
+      }
+    } else
       res = this._skipUntilEnd(buffer, fail);
 
     // Failure
     if (buffer.isError(res))
       return res;
-
-    if (tag.tagStr === 'end')
-      break;
-
-    parts.push({
-      start: res.offset,
-      end: res.length
-    })
   }
   return parts;
 };
@@ -142,7 +145,7 @@ DERNode.prototype._decodeList = function decodeList(buffer, tag, decoder,
 
 DERNode.prototype._decodeStr = function decodeStr(buffer, tag) {
   // Combine sub-strings if previously found
-  if (buffer.parts && (tag === 'bitstr' || tag === 'octstr')) {
+  if (buffer.parts) {
     return Buffer.concat(buffer.parts.map(function (p) {
       return buffer.base.slice(p.start, p.end);
     }));

--- a/lib/asn1/decoders/der.js
+++ b/lib/asn1/decoders/der.js
@@ -71,7 +71,8 @@ DERNode.prototype._decodeTag = function decodeTag(buffer, tag, any) {
   if (decodedTag.primitive || len !== null)
     return buffer.skip(len, 'Failed to match body of: "' + tag + '"');
 
-  // Indefinite length... find END tag
+  // Indefinite length
+
   var state = buffer.save();
   var res = this._skipUntilEnd(
       buffer,
@@ -79,12 +80,23 @@ DERNode.prototype._decodeTag = function decodeTag(buffer, tag, any) {
   if (buffer.isError(res))
     return res;
 
-  len = buffer.offset - state.offset;
-  buffer.restore(state);
-  return buffer.skip(len, 'Failed to match body of: "' + tag + '"');
+  if (res.length > 1) {
+    // Octet and bit strings can be composed of sub-strings, each with its own
+    // tag header. Return a merged result of each buffer.
+    var out = Buffer.concat(res.map(function (r) {
+      return r.raw();
+    }))
+    return new base.DecoderBuffer(out);
+  } else {
+    len = buffer.offset - state.offset;
+    buffer.restore(state);
+    return buffer.skip(len, 'Failed to match body of: "' + tag + '"');
+  }
 };
 
 DERNode.prototype._skipUntilEnd = function skipUntilEnd(buffer, fail) {
+  // Capture sub-components for later merging
+  var remainders = []
   while (true) {
     var tag = derDecodeTag(buffer, fail);
     if (buffer.isError(tag))
@@ -95,7 +107,7 @@ DERNode.prototype._skipUntilEnd = function skipUntilEnd(buffer, fail) {
 
     var res;
     if (tag.primitive || len !== null)
-      res = buffer.skip(len)
+      res = buffer.skip(len);
     else
       res = this._skipUntilEnd(buffer, fail);
 
@@ -105,7 +117,10 @@ DERNode.prototype._skipUntilEnd = function skipUntilEnd(buffer, fail) {
 
     if (tag.tagStr === 'end')
       break;
+
+    remainders.push(res);
   }
+  return remainders;
 };
 
 DERNode.prototype._decodeList = function decodeList(buffer, tag, decoder,

--- a/lib/asn1/decoders/der.js
+++ b/lib/asn1/decoders/der.js
@@ -80,23 +80,21 @@ DERNode.prototype._decodeTag = function decodeTag(buffer, tag, any) {
   if (buffer.isError(res))
     return res;
 
+  len = buffer.offset - state.offset;
+  buffer.restore(state);
+  var out = buffer.skip(len, 'Failed to match body of: "' + tag + '"');
+
   if (res.length > 1) {
     // Octet and bit strings can be composed of sub-strings, each with its own
-    // tag header. Return a merged result of each buffer.
-    var out = Buffer.concat(res.map(function (r) {
-      return r.raw();
-    }))
-    return new base.DecoderBuffer(out);
-  } else {
-    len = buffer.offset - state.offset;
-    buffer.restore(state);
-    return buffer.skip(len, 'Failed to match body of: "' + tag + '"');
+    // tag header. Flag for later decode.
+    out.parts = res
   }
+  return out
 };
 
 DERNode.prototype._skipUntilEnd = function skipUntilEnd(buffer, fail) {
   // Capture sub-components for later merging
-  var remainders = [];
+  var parts = [];
   while (true) {
     var tag = derDecodeTag(buffer, fail);
     if (buffer.isError(tag))
@@ -118,9 +116,12 @@ DERNode.prototype._skipUntilEnd = function skipUntilEnd(buffer, fail) {
     if (tag.tagStr === 'end')
       break;
 
-    remainders.push(res);
+    parts.push({
+      start: res.offset,
+      end: res.length
+    })
   }
-  return remainders;
+  return parts;
 };
 
 DERNode.prototype._decodeList = function decodeList(buffer, tag, decoder,
@@ -140,7 +141,12 @@ DERNode.prototype._decodeList = function decodeList(buffer, tag, decoder,
 };
 
 DERNode.prototype._decodeStr = function decodeStr(buffer, tag) {
-  if (tag === 'bitstr') {
+  // Combine sub-strings if previously found
+  if (buffer.parts && (tag === 'bitstr' || tag === 'octstr')) {
+    return Buffer.concat(buffer.parts.map(function (p) {
+      return buffer.base.slice(p.start, p.end);
+    }));
+  } else if (tag === 'bitstr') {
     var unused = buffer.readUInt8();
     if (buffer.isError(unused))
       return unused;

--- a/test/der-decode-test.js
+++ b/test/der-decode-test.js
@@ -157,4 +157,12 @@ describe('asn1.js DER decoder', function() {
      var decoded = M.decode(new Buffer('0101ff', 'hex'));
      assert.deepEqual(decoded, { 'type': 'apple', 'value': true });
   });
+
+  it('should decode components of indefinite length octet string', function() {
+    var A = asn1.define('A', function() {
+      this.key('test').implicit(0).octstr()
+    })
+    var out = A.decode(new Buffer('A0800401050401060401070000', 'hex'), 'der');
+    // assert.equal(out.test.toString(10), '050607')
+  });
 });

--- a/test/der-decode-test.js
+++ b/test/der-decode-test.js
@@ -158,11 +158,23 @@ describe('asn1.js DER decoder', function() {
      assert.deepEqual(decoded, { 'type': 'apple', 'value': true });
   });
 
-  it('should decode components of indefinite length octet string', function() {
+  it('should decode components of simple indefinite length octet string', function() {
     var A = asn1.define('A', function() {
       this.implicit(0).octstr()
     })
     var out = A.decode(new Buffer('A0800401050401060401070000', 'hex'), 'der');
     assert.deepEqual(out, new Buffer('050607', 'hex'))
+  });
+
+  it('should decode components of longer indefinite length structure', function() {
+    var A = asn1.define('A', function() {
+      this.key('seq').seq().obj(
+        this.key('int').int(),
+        this.key('oct').implicit(0).octstr()
+      )
+    })
+    var out = A.decode(new Buffer('3080020100A08004010504010604010700000000', 'hex'), 'der');
+    console.log('decoded', out)
+    assert.deepEqual(out.oct, new Buffer('050607', 'hex'))
   });
 });

--- a/test/der-decode-test.js
+++ b/test/der-decode-test.js
@@ -174,7 +174,6 @@ describe('asn1.js DER decoder', function() {
       )
     })
     var out = A.decode(new Buffer('3080020100A08004010504010604010700000000', 'hex'), 'der');
-    console.log('decoded', out)
     assert.deepEqual(out.oct, new Buffer('050607', 'hex'))
   });
 });

--- a/test/der-decode-test.js
+++ b/test/der-decode-test.js
@@ -160,9 +160,9 @@ describe('asn1.js DER decoder', function() {
 
   it('should decode components of indefinite length octet string', function() {
     var A = asn1.define('A', function() {
-      this.key('test').implicit(0).octstr()
+      this.implicit(0).octstr()
     })
     var out = A.decode(new Buffer('A0800401050401060401070000', 'hex'), 'der');
-    // assert.equal(out.test.toString(10), '050607')
+    assert.deepEqual(out, new Buffer('050607', 'hex'))
   });
 });

--- a/test/der-decode-test.js
+++ b/test/der-decode-test.js
@@ -169,11 +169,14 @@ describe('asn1.js DER decoder', function() {
   it('should decode components of longer indefinite length structure', function() {
     var A = asn1.define('A', function() {
       this.key('seq').seq().obj(
-        this.key('int').int(),
-        this.key('oct').implicit(0).octstr()
+        this.key('int1').int(),
+        this.key('oct').implicit(0).octstr(),
+        this.key('int2').int()
       )
     })
-    var out = A.decode(new Buffer('3080020100A08004010504010604010700000000', 'hex'), 'der');
+    var out = A.decode(new Buffer('3080020104A08004010504010604010700000201050000', 'hex'), 'der');
+    assert.equal(out.int1.toString(), '4')
     assert.deepEqual(out.oct, new Buffer('050607', 'hex'))
+    assert.equal(out.int2.toString(), '5')
   });
 });


### PR DESCRIPTION
See http://luca.ntop.org/Teaching/Appunti/asn1.html section 2.1 for a description:

> String types can be viewed, for the purposes of encoding, as consisting of components, where the components are substrings. This view allows one to encode a value whose length is not known in advance (e.g., an octet string value input from a file stream) with a constructed, indefinite- length encoding

We are seeing this in Java Bouncy Castle generated octet string blobs (10K+) using indefinite length encoding.

Added a test and all others still pass. Comments welcome.
