### PR TITLE
Check for captureStackTrace before use as its not available everywhere

### DIFF
--- a/lib/asn1/base/reporter.js
+++ b/lib/asn1/base/reporter.js
@@ -96,7 +96,8 @@ inherits(ReporterError, Error);
 
 ReporterError.prototype.rethrow = function rethrow(msg) {
   this.message = msg + ' at: ' + (this.path || '(shallow)');
-  Error.captureStackTrace(this, ReporterError);
+  if (Error.captureStackTrace)
+    Error.captureStackTrace(this, ReporterError);
 
   return this;
 };


### PR DESCRIPTION
If using asn1.js in browsers you may see this in IE, Edge, Safari and possibly others.