### PR TITLE
Add stack object to errors when called if needed

### DIFF
--- a/lib/asn1/base/reporter.js
+++ b/lib/asn1/base/reporter.js
@@ -66,6 +66,10 @@ Reporter.prototype.error = function error(msg) {
     err = new ReporterError(state.path.map(function(elem) {
       return '[' + JSON.stringify(elem) + ']';
     }).join(''), msg.message || msg, msg.stack);
+
+    // IE only adds stack when thrown
+    if (!err.stack)
+      err.stack = err.message
   }
 
   if (!state.options.partial)

--- a/lib/asn1/base/reporter.js
+++ b/lib/asn1/base/reporter.js
@@ -66,10 +66,6 @@ Reporter.prototype.error = function error(msg) {
     err = new ReporterError(state.path.map(function(elem) {
       return '[' + JSON.stringify(elem) + ']';
     }).join(''), msg.message || msg, msg.stack);
-
-    // IE only adds stack when thrown
-    if (!err.stack)
-      err.stack = err.message
   }
 
   if (!state.options.partial)
@@ -103,5 +99,13 @@ ReporterError.prototype.rethrow = function rethrow(msg) {
   if (Error.captureStackTrace)
     Error.captureStackTrace(this, ReporterError);
 
+  if (!this.stack) {
+    try {
+      // IE only adds stack when thrown
+      throw new Error(this.message);
+    } catch (e) {
+      this.stack = e.stack;
+    }
+  }
   return this;
 };


### PR DESCRIPTION
Edge (and IE?) only adds a stack object to Error once it is thrown. See
https://msdn.microsoft.com/en-us/library/hh699850(v=vs.94).aspx

We were getting strange errors in schema decoding on MS Edge which other browsers dealt with fine. Running this test suite via Karma in a variety of browsers helped to reveal this issue.