### PR TITLE
Remove limit for definite length decoding

### DIFF
--- a/lib/asn1/decoders/der.js
+++ b/lib/asn1/decoders/der.js
@@ -306,8 +306,6 @@ function derDecodeLen(buf, primitive, fail) {
 
   // Long form
   var num = len & 0x7f;
-  if (num >= 4)
-    return buf.error('length octect is too long');
 
   len = 0;
   for (var i = 0; i < num; i++) {


### PR DESCRIPTION
I don't believe there is any need for this restriction. It is stopping us deal with large encrypted files
