### PR TITLE
Increase limit for long form definite length decoding

### DIFF
--- a/lib/asn1/decoders/der.js
+++ b/lib/asn1/decoders/der.js
@@ -306,7 +306,7 @@ function derDecodeLen(buf, primitive, fail) {
 
   // Long form
   var num = len & 0x7f;
-  if (num >= 4)
+  if (num > 4)
     return buf.error('length octect is too long');
 
   len = 0;


### PR DESCRIPTION
(Was PR #74 but it didn't seem to reopen)

I cannot find any references to a limit of 3 bytes to encode the length. Java's Bouncy Castle seems to set the limit to 4 bytes seemingly due to the maximum size of an integer.

3 bytes limits us to only 16 megabytes (which we are reaching) so I have updated the patch to limit it to 4 bytes which is perhaps better than removing the restriction altogether.