### PR TITLE
Remove buffers `noAssert` argument

### DIFF
--- a/lib/asn1/base/buffer.js
+++ b/lib/asn1/base/buffer.js
@@ -40,7 +40,7 @@ DecoderBuffer.prototype.isEmpty = function isEmpty() {
 
 DecoderBuffer.prototype.readUInt8 = function readUInt8(fail) {
   if (this.offset + 1 <= this.length)
-    return this.base.readUInt8(this.offset++, true);
+    return this.base.readUInt8(this.offset++);
   else
     return this.error(fail || 'DecoderBuffer overrun');
 };


### PR DESCRIPTION
Support for the `noAssert` argument dropped in the upcoming Node.js
v.10. This removes the argument to make sure everything works as it
should.

Refs: https://github.com/nodejs/node/pull/18395