### PR TITLE
fixed multibyte tags decoding

### DIFF
--- a/lib/asn1/decoders/der.js
+++ b/lib/asn1/decoders/der.js
@@ -278,15 +278,15 @@ function derDecodeTag(buf, fail) {
 
   // Multi-octet tag - load
   if ((tag & 0x1f) === 0x1f) {
-    let oct = tag;
     tag = 0;
-    while ((oct & 0x80) === 0x80) {
-      oct = buf.readUInt8(fail);
+    while(1){
+      let oct = buf.readUInt8(fail);
       if (buf.isError(oct))
         return oct;
-
       tag <<= 7;
       tag |= oct & 0x7f;
+      if((oct & 0x80) !== 0x80)
+        break;
     }
   } else {
     tag &= 0x1f;


### PR DESCRIPTION
Current version has incorrect parsing of multibyte tags from DER format.
I am submitting fixed code.