### PR TITLE
der: encode integers > 4294967295 and BigInts

### DIFF
--- a/lib/asn1/encoders/der.js
+++ b/lib/asn1/encoders/der.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const inherits = require('inherits');
+const BN = require('bn.js');
 const Buffer = require('buffer').Buffer;
 const Node = require('../base/node');
 
@@ -194,7 +195,10 @@ DERNode.prototype._encodeInt = function encodeInt(num, values) {
   }
 
   // Bignum, assume big endian
-  if (typeof num !== 'number' && !Buffer.isBuffer(num)) {
+  if (!Buffer.isBuffer(num)) {
+    if (!BN.isBN(num)) {
+      num = new BN(num);
+    }
     const numArray = num.toArray();
     if (!num.sign && numArray[0] & 0x80) {
       numArray.unshift(0);
@@ -202,38 +206,15 @@ DERNode.prototype._encodeInt = function encodeInt(num, values) {
     num = new Buffer(numArray);
   }
 
-  if (Buffer.isBuffer(num)) {
-    let size = num.length;
-    if (num.length === 0)
-      size++;
-
-    const out = new Buffer(size);
-    num.copy(out);
-    if (num.length === 0)
-      out[0] = 0;
-    return this._createEncoderBuffer(out);
-  }
-
-  if (num < 0x80)
-    return this._createEncoderBuffer(num);
-
-  if (num < 0x100)
-    return this._createEncoderBuffer([0, num]);
-
-  let size = 1;
-  for (let i = num; i >= 0x100; i >>= 8)
+  let size = num.length;
+  if (num.length === 0)
     size++;
 
-  const out = new Array(size);
-  for (let i = out.length - 1; i >= 0; i--) {
-    out[i] = num & 0xff;
-    num >>= 8;
-  }
-  if(out[0] & 0x80) {
-    out.unshift(0);
-  }
-
-  return this._createEncoderBuffer(new Buffer(out));
+  const out = new Buffer(size);
+  num.copy(out);
+  if (num.length === 0)
+    out[0] = 0;
+  return this._createEncoderBuffer(out);
 };
 
 DERNode.prototype._encodeBool = function encodeBool(value) {


### PR DESCRIPTION
### Before

```JavaScript
const INTEGER = asn1.define('INTEGER', function() {
  this.int();
});
console.log(INTEGER.decode(INTEGER.encode(0x100000000))); // <BN: 0>
console.log(INTEGER.decode(INTEGER.encode(1n))); // TypeError: num.toArray is not a function
```

### After

```JavaScript
console.log(INTEGER.decode(INTEGER.encode(0x100000000))); // <BN: 100000000>
console.log(INTEGER.decode(INTEGER.encode(1n))); // <BN: 1>
```