### PR TITLE
Strict tag decoding

### DIFF
--- a/lib/asn1/base/node.js
+++ b/lib/asn1/base/node.js
@@ -325,7 +325,7 @@ Node.prototype._decode = function decode(input, options) {
   if (present) {
     // Unwrap explicit values
     if (state.explicit !== null) {
-      const explicit = this._decodeTag(input, state.explicit, false, 'context');
+      const explicit = this._decodeTag(input, 'context', false, state.explicit);
       if (input.isError(explicit))
         return explicit;
       input = explicit;
@@ -338,11 +338,19 @@ Node.prototype._decode = function decode(input, options) {
       let save;
       if (state.any)
         save = input.save();
+      const primitive = Boolean(
+        state.contains || 
+        (!state.choice && 
+         !state.children && 
+         !(state.tag === 'seqof') &&
+         !(state.tag === 'setof') && 
+         !state.use));
       const body = this._decodeTag(
         input,
+        state.implicit !== null ? 'context' : 'universal',
+        primitive,
         state.implicit !== null ? state.implicit : state.tag,
-        state.any,
-        state.implicit !== null ? 'context' : 'universal'
+        state.any
       );
       if (input.isError(body))
         return body;

--- a/lib/asn1/base/node.js
+++ b/lib/asn1/base/node.js
@@ -325,7 +325,7 @@ Node.prototype._decode = function decode(input, options) {
   if (present) {
     // Unwrap explicit values
     if (state.explicit !== null) {
-      const explicit = this._decodeTag(input, state.explicit);
+      const explicit = this._decodeTag(input, state.explicit, false, 'context');
       if (input.isError(explicit))
         return explicit;
       input = explicit;
@@ -341,7 +341,8 @@ Node.prototype._decode = function decode(input, options) {
       const body = this._decodeTag(
         input,
         state.implicit !== null ? state.implicit : state.tag,
-        state.any
+        state.any,
+        state.implicit !== null ? 'context' : 'universal'
       );
       if (input.isError(body))
         return body;

--- a/lib/asn1/decoders/der.js
+++ b/lib/asn1/decoders/der.js
@@ -50,7 +50,7 @@ DERNode.prototype._peekTag = function peekTag(buffer, tag, any) {
     (decodedTag.tagStr + 'of') === tag || any;
 };
 
-DERNode.prototype._decodeTag = function decodeTag(buffer, tag, any, cls = 'universal') {
+DERNode.prototype._decodeTag = function decodeTag(buffer, cls, primitive, tag, any) {
   const decodedTag = derDecodeTag(buffer,
     'Failed to decode tag of "' + tag + '"');
   if (buffer.isError(decodedTag))
@@ -67,6 +67,9 @@ DERNode.prototype._decodeTag = function decodeTag(buffer, tag, any, cls = 'unive
   if (!any) {
     if (decodedTag.cls !== cls) {
       return buffer.error('Failed to match tag class: "' + cls + '": decoded tag class is "' + decodedTag.cls + '"');
+    }
+    if (decodedTag.primitive !== primitive) {
+      return buffer.error('Failed to match tag primitive flag: "' + primitive + '": decoded tag primitive flag is "' + decodedTag.primitive + '"');
     }
     if (decodedTag.tag !== tag &&
         decodedTag.tagStr !== tag &&

--- a/lib/asn1/decoders/der.js
+++ b/lib/asn1/decoders/der.js
@@ -50,7 +50,7 @@ DERNode.prototype._peekTag = function peekTag(buffer, tag, any) {
     (decodedTag.tagStr + 'of') === tag || any;
 };
 
-DERNode.prototype._decodeTag = function decodeTag(buffer, tag, any) {
+DERNode.prototype._decodeTag = function decodeTag(buffer, tag, any, cls = 'universal') {
   const decodedTag = derDecodeTag(buffer,
     'Failed to decode tag of "' + tag + '"');
   if (buffer.isError(decodedTag))
@@ -64,11 +64,16 @@ DERNode.prototype._decodeTag = function decodeTag(buffer, tag, any) {
   if (buffer.isError(len))
     return len;
 
-  if (!any &&
-      decodedTag.tag !== tag &&
-      decodedTag.tagStr !== tag &&
-      decodedTag.tagStr + 'of' !== tag) {
-    return buffer.error('Failed to match tag: "' + tag + '"');
+  if (!any) {
+    if (decodedTag.cls !== cls) {
+      return buffer.error('Failed to match tag class: "' + cls + '": decoded tag class is "' + decodedTag.cls + '"');
+    }
+    if (decodedTag.tag !== tag &&
+        decodedTag.tagStr !== tag &&
+        decodedTag.tagStr + 'of' !== tag) {
+            
+      return buffer.error('Failed to match tag: "' + tag + '"');
+    }
   }
 
   if (decodedTag.primitive || len !== null)

--- a/test/der-decode-test.js
+++ b/test/der-decode-test.js
@@ -20,7 +20,7 @@ describe('asn1.js DER decoder', function() {
       );
     });
 
-    const out = A.decode(Buffer.from('300720050403313233', 'hex'), 'der');
+    const out = A.decode(Buffer.from('3007a0050403313233', 'hex'), 'der');
     assert.equal(out.a.b.toString(), '123');
   });
 

--- a/test/error-test.js
+++ b/test/error-test.js
@@ -180,7 +180,6 @@ describe('asn1.js error', function() {
         );
       }, 'B0030101ff', /Failed to match tag class: "universal"/);
 
-      // TODO
       test('incorrect tag primitive bit flag', function() {
         this.seq().obj(
           this.key('key').bool()
@@ -193,8 +192,6 @@ describe('asn1.js error', function() {
     function test(name, model, input, expectedObj, expectedErrs) {
       it('should support ' + name, function() {
         const M = asn1.define('TestModel', model);
-
-        // console.log(M.encode(expectedObj))
 
         const decoded = M.decode(Buffer.from(input, 'hex'), 'der', {
           partial: true

--- a/test/error-test.js
+++ b/test/error-test.js
@@ -128,7 +128,7 @@ describe('asn1.js error', function() {
     describe('primitive', function() {
       test('int', function() {
         this.int();
-      }, '2201', /body of: "int"/);
+      }, '0201', /body of: "int"/);
 
       test('int', function() {
         this.int();
@@ -185,7 +185,7 @@ describe('asn1.js error', function() {
         this.seq().obj(
           this.key('key').bool()
         );
-      }, '10030101ff', /Failed to match tag primitive bit flag/);
+      }, '10030101ff', /Failed to match tag primitive flag/);
     });
   });
 
@@ -193,6 +193,8 @@ describe('asn1.js error', function() {
     function test(name, model, input, expectedObj, expectedErrs) {
       it('should support ' + name, function() {
         const M = asn1.define('TestModel', model);
+
+        // console.log(M.encode(expectedObj))
 
         const decoded = M.decode(Buffer.from(input, 'hex'), 'der', {
           partial: true
@@ -218,7 +220,7 @@ describe('asn1.js error', function() {
           this.key('d').int()
         )
       );
-    }, '30073005300022012e', { a: { b: {}, d: new bn(46) } }, [
+    }, '30073005300002012e', { a: { b: {}, d: new bn(46) } }, [
       /"int" at: \["a"\]\["b"\]\["c"\]/
     ]);
 
@@ -231,7 +233,7 @@ describe('asn1.js error', function() {
           this.key('d').int()
         )
       );
-    }, '30073005300322012e', { a: { b: { c: new bn(46) } } }, [
+    }, '30073005300302012e', { a: { b: { c: new bn(46) } } }, [
       /"int" at: \["a"\]\["d"\]/
     ]);
   });

--- a/test/error-test.js
+++ b/test/error-test.js
@@ -173,6 +173,19 @@ describe('asn1.js error', function() {
           )
         );
       }, '30053003300122', /length of "int" at: \["a"\]\["b"\]\["c"\]/);
+
+      test('incorrect tag class', function() {
+        this.seq().obj(
+          this.key('key').bool()
+        );
+      }, 'B0030101ff', /Failed to match tag class: "universal"/);
+
+      // TODO
+      test('incorrect tag primitive bit flag', function() {
+        this.seq().obj(
+          this.key('key').bool()
+        );
+      }, '10030101ff', /Failed to match tag primitive bit flag/);
     });
   });
 


### PR DESCRIPTION
Tag decoding was ignoring the first three bits of the tag (tag class and primitive bit).

Fixing this also broke a few tests that had technically incorrect payloads, so those have been patched as well.