### PR TITLE
use(fn) inside choice

### DIFF
--- a/lib/asn1/base/node.js
+++ b/lib/asn1/base/node.js
@@ -524,7 +524,7 @@ Node.prototype._encodeValue = function encode(data, reporter, parent) {
     // Anything that was given is translated to buffer
     result = this._createEncoderBuffer(data);
   } else if (state.choice) {
-    result = this._encodeChoice(data, reporter);
+    result = this._encodeChoice(data, reporter, parent);
   } else if (state.contains) {
     content = this._getUse(state.contains, parent)._encode(data, reporter);
     primitive = true;
@@ -593,7 +593,7 @@ Node.prototype._encodeValue = function encode(data, reporter, parent) {
   return result;
 };
 
-Node.prototype._encodeChoice = function encodeChoice(data, reporter) {
+Node.prototype._encodeChoice = function encodeChoice(data, reporter, parent) {
   const state = this._baseState;
 
   const node = state.choice[data.type];
@@ -603,7 +603,7 @@ Node.prototype._encodeChoice = function encodeChoice(data, reporter) {
       data.type + ' not found in ' +
             JSON.stringify(Object.keys(state.choice)));
   }
-  return node._encode(data.value, reporter);
+  return node._encode(data.value, reporter, parent);
 };
 
 Node.prototype._encodePrimitive = function encodePrimitive(tag, data) {


### PR DESCRIPTION
Bug: When `use((ob)=> Model)` is used as direct descendant of choice, reference to the object being serialized is not provided.

This commit fixes the issue.